### PR TITLE
reverted parts of pull #11 and# 12

### DIFF
--- a/Intersting_Post_ScoreScreen/source/lua/Devnull_IPS/GUIGameEndStats.lua
+++ b/Intersting_Post_ScoreScreen/source/lua/Devnull_IPS/GUIGameEndStats.lua
@@ -1880,14 +1880,7 @@ function GUIGameEndStats:LoadLastRoundStats()
             local parsedFile = json.decode(openedFile:read("*all"))
             io.close(openedFile)
 
-            if parsedFile and parsedFile.miscDataTable and parsedFile.miscDataTable.serverName then
-                local serverName = Client.GetServerIsHidden() and "Hidden" or Client.GetConnectedServerName()
-                if serverName ~= 'Listen Server' and serverName ~= parsedFile.miscDataTable.serverName then
-                    print("Data is not from this server so will not load it.")
-                    return
-                end
-            end
-
+    
             if parsedFile then
                 finalStatsTable = parsedFile.finalStatsTable or {}
                 avgAccTable = parsedFile.avgAccTable or {}
@@ -5185,7 +5178,7 @@ function GUIGameEndStats:SendKeyEvent(key, down)
             local isVisible = self:GetIsVisible()
             if isVisible then
                 self:SetIsVisible(false)
-            elseif lastDown + kKeyTapTiming > Shared.GetTime() and loadedLastRound then
+            elseif lastDown + kKeyTapTiming > Shared.GetTime() then
                 self:SetIsVisible(true)
             end
         end


### PR DESCRIPTION
Currently we have issues with people being unable to open the stat window even after finishing a round on a server
or they see sometimes the stats of the previous round. 

I removed the most recent changes which hopefully fixes this. 
This could mean that the statpage will show wrong stats when switching between the balance mod and vanilla, but this is a smaller issue.